### PR TITLE
Add Python 3 support.

### DIFF
--- a/amazon_kclpy/kcl.py
+++ b/amazon_kclpy/kcl.py
@@ -12,7 +12,9 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 '''
+from __future__ import absolute_import
 import abc, base64, io, json, os, random, sys, time, traceback
+import six
 
 class _IOHandler(object):
     '''
@@ -156,7 +158,7 @@ class Checkpointer(object):
             raise CheckpointError('InvalidStateException')
 
 # RecordProcessor base class
-class RecordProcessorBase(object):
+class RecordProcessorBase(six.with_metaclass(abc.ABCMeta, object)):
     '''
     Base class for implementing a record processor.A RecordProcessor processes a shard in a stream.
     Its methods will be called with this pattern:
@@ -165,7 +167,6 @@ class RecordProcessorBase(object):
     - process_records will be called zero or more times
     - shutdown will be called if this MultiLangDaemon instance loses the lease to this shard
     '''
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def initialize(self, shard_id):

--- a/samples/amazon_kclpy_helper.py
+++ b/samples/amazon_kclpy_helper.py
@@ -14,6 +14,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 from amazon_kclpy import kcl
 from glob import glob
 import os, argparse, sys, samples

--- a/samples/sample_kclpy_app.py
+++ b/samples/sample_kclpy_app.py
@@ -14,8 +14,10 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 import sys, time, json, base64
 from amazon_kclpy import kcl
+from six.moves import range
 
 class RecordProcessor(kcl.RecordProcessorBase):
     '''

--- a/samples/sample_kinesis_wordputter.py
+++ b/samples/sample_kinesis_wordputter.py
@@ -14,6 +14,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 import sys, random, time, argparse
 from boto import kinesis
 

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,12 @@ to rerun the install command.
 '''
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '1.3.1'
+PACKAGE_VERSION = '1.4.1'
 PYTHON_REQUIREMENTS = [
             'boto',
             # argparse is part of python2.7 but must be declared for python2.6
             'argparse',
+            'six',
         ]
 REMOTE_MAVEN_PACKAGES = [
         # (group id, artifact id, version),
@@ -215,4 +216,13 @@ if __name__ == '__main__':
         url = "https://github.com/awslabs/amazon-kinesis-client-python",
         keywords = "amazon kinesis client library python",
         zip_safe      = False,
+        classifiers=(
+            'Intended Audience :: Developers',
+            'Intended Audience :: System Administrators',
+            'Natural Language :: English',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2.6',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+        ),
         )


### PR DESCRIPTION
This is a mechanical translation to Python 3 using python-modernize.  For the most
part this was a straight forward conversion.

This PR relies on `six`.  I see `botocore` vendors in `six` instead of
declaring it as a dependency, which I can also do if that's what you'd
prefer.
