### PR TITLE
fix(setup) Missing on_completion param for MavenJarDownloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /build/
 /dist/
 /docs/_build/
+
+# IntelliJ idea stuff
+.idea

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ class DownloadJarsCommand(Command):
         """
         Runs when this command is given to setup.py
         """
-        downloader = MavenJarDownloader()
+        downloader = MavenJarDownloader(on_completion=lambda : None)
         downloader.download_files()
         print('''
 Now you should run:


### PR DESCRIPTION
This was causing:
```
(amazon-kinesis-client-python)➜  amazon-kinesis-client-python git:(master) ✗ python setup.py download_jars
running download_jars
Traceback (most recent call last):
  File "setup.py", line 253, in <module>
    zip_safe=False,
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "setup.py", line 172, in run
    downloader = MavenJarDownloader()
TypeError: __init__() takes at least 2 arguments (1 given)

```