### PR TITLE
Fixes executableName path in sample.

### DIFF
--- a/samples/sample.properties
+++ b/samples/sample.properties
@@ -1,7 +1,7 @@
 # The script that abides by the multi-language protocol. This script will
 # be executed by the MultiLangDaemon, which will communicate with this script
 # over STDIN and STDOUT according to the multi-language protocol.
-executableName = sample_kclpy_app.py
+executableName = samples/sample_kclpy_app.py
 
 # The name of an Amazon Kinesis stream to process.
 streamName = words


### PR DESCRIPTION
Without this change, sample_kclypy_app.py will never be initialized