### PR TITLE
Make Record Subscriptable

### DIFF
--- a/amazon_kclpy/messages.py
+++ b/amazon_kclpy/messages.py
@@ -368,4 +368,7 @@ class Record(object):
 
     def get(self, field):
         return self._json_dict[field]
+    
+    def __getitem__(self, field):
+        return self.get(field)
 


### PR DESCRIPTION
Previously the `record` that was passed was subscriptable as it was a simple dictionary.  This mechanism means that I am still able to do `record['data']` thereby maintaining backwards compatibility.