### PR TITLE
shutdown_requested Should not be Abstract

### DIFF
--- a/amazon_kclpy/kcl.py
+++ b/amazon_kclpy/kcl.py
@@ -220,7 +220,6 @@ class RecordProcessorBase(object):
         '''
         raise NotImplementedError
 
-    @abc.abstractmethod
     def shutdown_requested(self, checkpointer):
         """
         Called by a KCLProcess instance to indicate that this record processor is about to be be shutdown.  This gives

--- a/amazon_kclpy/v2/processor.py
+++ b/amazon_kclpy/v2/processor.py
@@ -73,7 +73,6 @@ class RecordProcessorBase(object):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
     def shutdown_requested(self, shutdown_requested_input):
         """
         Called by a KCLProcess instance to indicate that this record processor is about to be be shutdown.  This gives


### PR DESCRIPTION
Existing users should be able to upgrade the library without issues.
Removed the abstract decorator to ensure that existing users'
applications continue to work normally.