### PR TITLE
Added aws-java-sdk-sts to jar-dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ REMOTE_MAVEN_PACKAGES = [
     ('com.amazonaws', 'aws-java-sdk-s3', '1.11.151'),
     ('com.amazonaws', 'aws-java-sdk-kms', '1.11.151'),
     ('com.amazonaws', 'aws-java-sdk-core', '1.11.151'),
+    ('com.amazonaws', 'aws-java-sdk-sts', '1.11.151'),
     ('org.apache.httpcomponents', 'httpclient', '4.5.2'),
     ('org.apache.httpcomponents', 'httpcore', '4.4.4'),
     ('commons-codec', 'commons-codec', '1.9'),


### PR DESCRIPTION
This would allow using `STSAssumeRoleSessionCredentialsProvider` for assume-roles authorization, for example in case of CrossAccount signin.

Properties example:
```
AWSCredentialsProvider = STSAssumeRoleSessionCredentialsProvider|arn:aws:iam::<uid>:role/CrossAccountSignIn|<session>
```