### PR TITLE
 Update to 1.9.0 release of the KCL

### DIFF
--- a/amazon_kclpy/kcl.py
+++ b/amazon_kclpy/kcl.py
@@ -265,6 +265,9 @@ class KCLProcess(object):
 
         try:
             action.dispatch(self.checkpointer, self.processor)
+        except SystemExit as sys_exit:
+            # On a system exit exception just go ahead and exit
+            raise sys_exit
         except:
             '''
             We don't know what the client's code could raise and we have no way to recover if we let it propagate

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '1.4.5'
+PACKAGE_VERSION = '1.5.0'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6
@@ -59,23 +59,23 @@ PYTHON_REQUIREMENTS = [
 ]
 REMOTE_MAVEN_PACKAGES = [
     # (group id, artifact id, version),
-    ('com.amazonaws', 'amazon-kinesis-client', '1.7.6'),
-    ('com.amazonaws', 'aws-java-sdk-dynamodb', '1.11.151'),
-    ('com.amazonaws', 'aws-java-sdk-s3', '1.11.151'),
-    ('com.amazonaws', 'aws-java-sdk-kms', '1.11.151'),
-    ('com.amazonaws', 'aws-java-sdk-core', '1.11.151'),
+    ('com.amazonaws', 'amazon-kinesis-client', '1.9.0'),
+    ('com.amazonaws', 'aws-java-sdk-dynamodb', '1.11.272'),
+    ('com.amazonaws', 'aws-java-sdk-s3', '1.11.272'),
+    ('com.amazonaws', 'aws-java-sdk-kms', '1.11.272'),
+    ('com.amazonaws', 'aws-java-sdk-core', '1.11.272'),
     ('org.apache.httpcomponents', 'httpclient', '4.5.2'),
     ('org.apache.httpcomponents', 'httpcore', '4.4.4'),
     ('commons-codec', 'commons-codec', '1.9'),
     ('software.amazon.ion', 'ion-java', '1.0.2'),
-    ('com.fasterxml.jackson.core', 'jackson-databind', '2.6.6'),
+    ('com.fasterxml.jackson.core', 'jackson-databind', '2.6.7.1'),
     ('com.fasterxml.jackson.core', 'jackson-annotations', '2.6.0'),
-    ('com.fasterxml.jackson.core', 'jackson-core', '2.6.6'),
-    ('com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.6.6'),
+    ('com.fasterxml.jackson.core', 'jackson-core', '2.6.7'),
+    ('com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.6.7'),
     ('joda-time', 'joda-time', '2.8.1'),
-    ('com.amazonaws', 'jmespath-java', '1.11.151'),
-    ('com.amazonaws', 'aws-java-sdk-kinesis', '1.11.151'),
-    ('com.amazonaws', 'aws-java-sdk-cloudwatch', '1.11.151'),
+    ('com.amazonaws', 'jmespath-java', '1.11.272'),
+    ('com.amazonaws', 'aws-java-sdk-kinesis', '1.11.272'),
+    ('com.amazonaws', 'aws-java-sdk-cloudwatch', '1.11.272'),
     ('com.google.guava', 'guava', '18.0'),
     ('com.google.protobuf', 'protobuf-java', '2.6.1'),
     ('commons-lang', 'commons-lang', '2.6'),


### PR DESCRIPTION
Updated to the 1.9.0 release of the Kinesis Client Library (KCL) for Java.
Also moved to 1.5.0 since it's a minor bump on the KCL.

Includes an old commit to not catch exiting exceptions.