### PR TITLE
Release 1.5.0 of the Amazon Kinesis Client for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ all languages.
 
 ## Release Notes
 
+### Release 1.5.9 (February 7, 2018)
+* Updated to version 1.9.0 of the Amazon Kinesis Client Library for Java
+  * Version 1.9.0 now uses the [`ListShards` Kinesis API](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html), which provides a higher call rate than `DescribeStream`.
+  * __WARNING: `ListShards` is a new API, and may require updating any explicit IAM policies__
+  * [PR #71](https://github.com/awslabs/amazon-kinesis-client-python/pull/71)
+
 ### Release 1.4.5 (June 28, 2017)
 * Record processors can now be notified, and given a final opportunity to checkpoint, when the KCL is being shutdown.
   * [PR #53](https://github.com/awslabs/amazon-kinesis-client-python/pull/53)


### PR DESCRIPTION
* Updated to version 1.9.0 of the Amazon Kinesis Client for Java
  Version 1.9.0 now uses ListShards, instead of DescribeStream.