### PR TITLE
mock is not a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6
     'argparse',
-    'mock'
 
 ]
 REMOTE_MAVEN_PACKAGES = [


### PR DESCRIPTION
I'd like to avoid installing `mock` in my production application -- it appears `mock` is only used for kclpy's tests?