### PR TITLE
Release 1.5.1 of the Amazon Kinesis Client Library for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ all languages.
 
 ## Release Notes
 
+### Release 1.5.1 (January 2, 2019)
+* Updated to version 1.9.3 of the Amazon Kinesis Client Library for Java.
+  * [PR #87](https://github.com/awslabs/amazon-kinesis-client-python/pull/87)
+* Changed to now download jars from Maven using https.
+  * [PR #87](https://github.com/awslabs/amazon-kinesis-client-python/pull/87)
+
 ### Release 1.5.0 (February 7, 2018)
 * Updated to version 1.9.0 of the Amazon Kinesis Client Library for Java
   * Version 1.9.0 now uses the [`ListShards` Kinesis API](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html), which provides a higher call rate than `DescribeStream`.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ all languages.
   * [PR #87](https://github.com/awslabs/amazon-kinesis-client-python/pull/87)
 * Changed to now download jars from Maven using https.
   * [PR #87](https://github.com/awslabs/amazon-kinesis-client-python/pull/87)
+* Changed to raise exception when downloading from Maven fails.
+  * [PR #80](https://github.com/awslabs/amazon-kinesis-client-python/pull/80)
 
 ### Release 1.5.0 (February 7, 2018)
 * Updated to version 1.9.0 of the Amazon Kinesis Client Library for Java

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '1.5.0'
+PACKAGE_VERSION = '1.5.1'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Updated to version 1.9.3 of the Amazon Kinesis Client Library for Java.
  * https://github.com/awslabs/amazon-kinesis-client-python/pull/87
* Changed to now download jars from Maven using https.
  * https://github.com/awslabs/amazon-kinesis-client-python/pull/87
* Changed to raise exception when downloading from Maven fails.
  * https://github.com/awslabs/amazon-kinesis-client-python/pull/80

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
