### PR TITLE
applying backoff for rate-limited Maven downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,8 +213,9 @@ Which will download the required jars and rerun the install.
                     sleep_time = 2 ** attempt_number
                     print('"429 Too Many Requests" response received. Sleeping {} seconds and trying again.'.format(sleep_time))
                     sleep(sleep_time)
-            else:
-                return response
+                else:
+                    raise
+        
         raise Exception('"429 Too Many Requests" responses received.')
 
 


### PR DESCRIPTION
*Issue #, if available:* #99 

*Description of changes:*
When a 429 response is received when attempting to download one of the jars, this will apply exponential backoff, sleeping anywhere between 1 second (on the first retry) to 16 (on the final retry).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
