### PR TITLE
Remove unused attribute from sample app

### DIFF
--- a/samples/sample_kclpy_app.py
+++ b/samples/sample_kclpy_app.py
@@ -26,7 +26,6 @@ class RecordProcessor(processor.RecordProcessorBase):
         self._CHECKPOINT_RETRIES = 5
         self._CHECKPOINT_FREQ_SECONDS = 60
         self._largest_seq = (None, None)
-        self._largest_sub_seq = None
         self._last_checkpoint_time = None
 
     def log(self, message):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`_largest_sub_seq` is unused; this just cleans that up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
