### PR TITLE
docs: Fix a few typos

### DIFF
--- a/amazon_kclpy/dispatch.py
+++ b/amazon_kclpy/dispatch.py
@@ -36,7 +36,7 @@ def message_decode(json_dict):
     :return: an object that can be used to dispatch the received JSON command
     :rtype: amazon_kclpy.messages.MessageDispatcher
 
-    :raises MalformedAction: if the JSON object is missing action, or an appropiate serializer for that
+    :raises MalformedAction: if the JSON object is missing action, or an appropriate serializer for that
         action can't be found
     """
     try:

--- a/amazon_kclpy/kcl.py
+++ b/amazon_kclpy/kcl.py
@@ -30,7 +30,7 @@ class _IOHandler(object):
 
     def write_line(self, line):
         """
-        Writes a line to the output file. The line is preceeded and followed by a new line because other libraries
+        Writes a line to the output file. The line is preceded and followed by a new line because other libraries
         could be writing to the output file as well (e.g. some libs might write debugging info to STDOUT) so we would
         like to prevent our lines from being interlaced with other messages so the MultiLangDaemon can understand them.
 
@@ -65,7 +65,7 @@ class _IOHandler(object):
             '{"action" : "initialize", "shardId" : "shardId-000001"}')
 
         :rtype: amazon_kclpy.messages.MessageDispatcher
-        :return: A callabe action class that contains the action presented in the line
+        :return: A callable action class that contains the action presented in the line
         """
         return json.loads(line, object_hook=dispatch.message_decode)
 

--- a/amazon_kclpy/messages.py
+++ b/amazon_kclpy/messages.py
@@ -281,7 +281,7 @@ class ShardEndedInput(MessageDispatcher):
         """
         Dispatches the shard ended message to the record processor
 
-        :param checkpointer: the checkpointer to be used to officialy end processing on the shard
+        :param checkpointer: the checkpointer to be used to officially end processing on the shard
         :param record_processor: the record processor that will handle the shard end message
         """
         self._checkpointer = checkpointer
@@ -376,7 +376,7 @@ class CheckpointInput(object):
 
 class Record(object):
     """
-    Represents a single record as returned by Kinesis, or Deaggregated from the Kinesis Producer Library
+    Represents a single record as returned by Kinesis, or Disaggregated from the Kinesis Producer Library
     """
     def __init__(self, json_dict):
         """
@@ -428,7 +428,7 @@ class Record(object):
     @property
     def sub_sequence_number(self):
         """
-        The sub-sequence number of this record.  This is only populated when the record is a deaggregated
+        The sub-sequence number of this record.  This is only populated when the record is a disaggregated
         record produced by the `amazon-kinesis-producer-library <https://github.com/awslabs/amazon-kinesis-producer>`
 
         :return: the sub-sequence number

--- a/samples/amazon_kclpy_helper.py
+++ b/samples/amazon_kclpy_helper.py
@@ -105,7 +105,7 @@ def get_kcl_app_command(args, multi_lang_daemon_class, properties, log_configura
     return "{java} -cp {cp} {daemon} {props} {log_config}".format(java=args.java,
                                     cp = get_kcl_classpath(args.properties, paths),
                                     daemon = multi_lang_daemon_class,
-                                    # Just need the basename becasue the path is added to the classpath
+                                    # Just need the basename because the path is added to the classpath
                                     props = properties,
                                     log_config = log_configuration)
 

--- a/samples/sample_kclpy_app.py
+++ b/samples/sample_kclpy_app.py
@@ -85,7 +85,7 @@ class RecordProcessor(processor.RecordProcessorBase):
         Called for each record that is passed to process_records.
 
         :param str data: The blob of data that was contained in the record.
-        :param str partition_key: The key associated with this recod.
+        :param str partition_key: The key associated with this record.
         :param int sequence_number: The sequence number associated with this record.
         :param int sub_sequence_number: the sub sequence number associated with this record.
         """


### PR DESCRIPTION
There are small typos in:
- amazon_kclpy/dispatch.py
- amazon_kclpy/kcl.py
- amazon_kclpy/messages.py
- samples/amazon_kclpy_helper.py
- samples/sample_kclpy_app.py

Fixes:
- Should read `record` rather than `recod`.
- Should read `preceded` rather than `preceeded`.
- Should read `officially` rather than `officialy`.
- Should read `disaggregated` rather than `deaggregated`.
- Should read `callable` rather than `callabe`.
- Should read `because` rather than `becasue`.
- Should read `appropriate` rather than `appropiate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md