### PR TITLE
Release 2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ all languages.
 
 ## Release Notes
 
+### Release 2.0.6 (November 23, 2021)
+* Upgraded multiple dependencies [PR #152](https://github.com/awslabs/amazon-kinesis-client-python/pull/152)
+  * Amazon Kinesis Client Library 2.3.9
+  * ch.qos.logback 1.2.7
+
 ### Release 2.0.5 (November 11, 2021)
 * Upgraded multiple dependencies [PR #148](https://github.com/awslabs/amazon-kinesis-client-python/pull/148)
   * Amazon Kinesis Client Library 2.3.8

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.0.5'
+PACKAGE_VERSION = '2.0.6'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6
@@ -73,8 +73,8 @@ REMOTE_MAVEN_PACKAGES = [
     ('software.amazon.eventstream', 'eventstream', '1.0.1'),
     ('software.amazon.ion', 'ion-java', '1.5.1'),
     ('software.amazon.glue', 'schema-registry-serde', '1.1.5'),
-    ('software.amazon.kinesis', 'amazon-kinesis-client-multilang', '2.3.8'),
-    ('software.amazon.kinesis', 'amazon-kinesis-client', '2.3.8'),
+    ('software.amazon.kinesis', 'amazon-kinesis-client-multilang', '2.3.9'),
+    ('software.amazon.kinesis', 'amazon-kinesis-client', '2.3.9'),
     ('com.amazonaws', 'aws-java-sdk-core', '1.12.3'),
     ('com.amazonaws', 'aws-java-sdk-sts', '1.12.3'),
     ('com.amazonaws', 'jmespath-java', '1.12.3'),
@@ -114,8 +114,8 @@ REMOTE_MAVEN_PACKAGES = [
     ('commons-collections', 'commons-collections', '3.2.2'),
     ('commons-io', 'commons-io', '2.9.0'),
     ('commons-logging', 'commons-logging', '1.2'),
-    ('ch.qos.logback', 'logback-classic', '1.2.3'),
-    ('ch.qos.logback', 'logback-core', '1.2.3'),
+    ('ch.qos.logback', 'logback-classic', '1.2.7'),
+    ('ch.qos.logback', 'logback-core', '1.2.7'),
     ('joda-time', 'joda-time', '2.10.10')
 ]
 


### PR DESCRIPTION
*Issue #, if available:*
Upgrade dependencies version
*Description of changes:*
### Release 2.0.6 (November 23, 2021)
* Upgraded multiple dependencies 
  * Amazon Kinesis Client Library 2.3.9
  * ch.qos.logback 1.2.7
  
*Testing:*
Ran amazon_kclpy_helper.py with -l logback.xml file below
```
<configuration>

  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
    <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
    <encoder>
      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
    </encoder>
  </appender>

  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
    <file>logFile.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>

      <!-- keep 30 days' worth of history -->
      <maxHistory>30</maxHistory>
    </rollingPolicy>

    <encoder>
      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
    </encoder>
  </appender>

  <root level="info">
    <appender-ref ref="FILE" />
    <appender-ref ref="STDOUT" />
  </root>
</configuration>
```
Was able to see log file output ```logFile.log``` and ```logFile.2021-11-23``` with STDOUT log
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
