### PR TITLE
Bump fasterxml-jackson from 2.13.1 to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
         <awssdk.version>2.17.100</awssdk.version>
         <aws-java-sdk.version>1.12.3</aws-java-sdk.version>
         <netty.version>4.1.72.Final</netty.version>
-        <fasterxml-jackson.version>2.13.1</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.13.3</fasterxml-jackson.version>
         <logback.version>1.2.10</logback.version>
     </properties>
     <dependencies>


### PR DESCRIPTION

Required to remove [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518).

Related to #166.