### PR TITLE
Prepare for KCL Python Release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ all languages.
 
 ## Release Notes
 
+### Release 2.1.0 (January 12, 2023)
+* Upgraded to use version 2.4.4 of the [Amazon Kinesis Client library][kinesis-github]
+
 ### Release 2.0.6 (November 23, 2021)
 * Upgraded multiple dependencies [PR #152](https://github.com/awslabs/amazon-kinesis-client-python/pull/152)
   * Amazon Kinesis Client Library 2.3.9

--- a/pom.xml
+++ b/pom.xml
@@ -2,56 +2,27 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <awssdk.version>2.17.100</awssdk.version>
-        <aws-java-sdk.version>1.12.3</aws-java-sdk.version>
-        <netty.version>4.1.72.Final</netty.version>
-        <fasterxml-jackson.version>2.13.1</fasterxml-jackson.version>
-        <logback.version>1.2.10</logback.version>
+        <awssdk.version>2.19.2</awssdk.version>
+        <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
+        <netty.version>4.1.86.Final</netty.version>
+        <netty-reactive.version>2.0.6</netty-reactive.version>
+        <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
+        <logback.version>1.3.0</logback.version>
     </properties>
     <dependencies>
         <dependency>
+            <groupId>software.amazon.kinesis</groupId>
+            <artifactId>amazon-kinesis-client-multilang</artifactId>
+            <version>2.4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.kinesis</groupId>
+            <artifactId>amazon-kinesis-client</artifactId>
+            <version>2.4.4</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kinesis</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>annotations</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>apache-client</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>auth</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-cbor-protocol</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-json-protocol</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-query-protocol</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>cloudwatch</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
@@ -61,17 +32,7 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>http-client-spi</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>json-utils</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>metrics-spi</artifactId>
+            <artifactId>cloudwatch</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
@@ -81,27 +42,37 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>protocol-core</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>profiles</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sdk-core</artifactId>
+            <artifactId>metrics-spi</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-cbor-protocol</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-json-protocol</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>json-utils</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
@@ -116,68 +87,53 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>endpoints-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.eventstream</groupId>
-            <artifactId>eventstream</artifactId>
-            <version>1.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.ion</groupId>
-            <artifactId>ion-java</artifactId>
-            <version>1.5.1</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.5</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.kinesis</groupId>
-            <artifactId>amazon-kinesis-client-multilang</artifactId>
-            <version>2.3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.kinesis</groupId>
-            <artifactId>amazon-kinesis-client</artifactId>
-            <version>2.3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>${aws-java-sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${aws-java-sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>jmespath-java</artifactId>
-            <version>1.12.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml-jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${fasterxml-jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${fasterxml-jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>${fasterxml-jackson.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -230,14 +186,19 @@
             <version>${netty.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>2.2.21</version>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams-http</artifactId>
+            <version>${netty-reactive.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-            <version>1.81</version>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams</artifactId>
+            <version>${netty-reactive.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -250,6 +211,11 @@
             <version>3.0.2</version>
         </dependency>
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <version>2.7.1</version>
@@ -260,19 +226,14 @@
             <version>1.3</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <version>1.20</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.netty</groupId>
-            <artifactId>netty-reactive-streams-http</artifactId>
-            <version>2.0.5</version>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.netty</groupId>
-            <artifactId>netty-reactive-streams</artifactId>
-            <version>2.0.5</version>
+            <version>3.21.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -280,9 +241,39 @@
             <version>3.12.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>3.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon</groupId>
+            <artifactId>flow</artifactId>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -290,54 +281,34 @@
             <version>4.5.13</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.15</version>
-        </dependency>
-        <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>2.5.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>animal-sniffer-annotations</artifactId>
-            <version>1.20</version>
-        </dependency>
-        <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.15</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.9.0</version>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <groupId>software.amazon.ion</groupId>
+            <artifactId>ion-java</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>schema-registry-serde</artifactId>
+            <version>1.1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.13</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -350,9 +321,34 @@
             <version>${logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10.10</version>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.82</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/sample_kinesis_wordputter.py
+++ b/samples/sample_kinesis_wordputter.py
@@ -4,62 +4,58 @@ Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 '''
 from __future__ import print_function
-import sys, random, time, argparse
-from boto import kinesis
 
-def get_stream_status(conn, stream_name):
+import argparse
+import sys
+import time
+
+import boto3
+
+def get_stream_status(kinesis, stream_name):
     '''
     Query this provided connection object for the provided stream's status.
-
-    :type conn: boto.kinesis.layer1.KinesisConnection
+    :type conn: Kinesis.Client
     :param conn: A connection to Amazon Kinesis
-
     :type stream_name: str
     :param stream_name: The name of a stream.
-
     :rtype: str
     :return: The stream's status
     '''
-    r = conn.describe_stream(stream_name)
+    r = kinesis.describe_stream(StreamName=stream_name)
     description = r.get('StreamDescription')
     return description.get('StreamStatus')
 
-def wait_for_stream(conn, stream_name):
+def wait_for_stream(kinesis, stream_name):
     '''
     Wait for the provided stream to become active.
-
-    :type conn: boto.kinesis.layer1.KinesisConnection
-    :param conn: A connection to Amazon Kinesis
-
+    :type kinesis: Kinesis.Client
+    :param kinesis: A low-level client representing Amazon Kinesis
     :type stream_name: str
     :param stream_name: The name of a stream.
     '''
     SLEEP_TIME_SECONDS = 3
-    status = get_stream_status(conn, stream_name)
+    status = get_stream_status(kinesis, stream_name)
     while status != 'ACTIVE':
         print('{stream_name} has status: {status}, sleeping for {secs} seconds'.format(
                 stream_name = stream_name,
                 status      = status,
                 secs        = SLEEP_TIME_SECONDS))
         time.sleep(SLEEP_TIME_SECONDS) # sleep for 3 seconds
-        status = get_stream_status(conn, stream_name)
+        status = get_stream_status(kinesis, stream_name)
 
-def put_words_in_stream(conn, stream_name, words):
+def put_words_in_stream(kinesis, stream_name, words):
     '''
     Put each word in the provided list of words into the stream.
-
-    :type conn: boto.kinesis.layer1.KinesisConnection
-    :param conn: A connection to Amazon Kinesis
-
+    :type kinesis: Kinesis.Client
+    :param kinesis: A connection to Amazon Kinesis
     :type stream_name: str
     :param stream_name: The name of a stream.
-
     :type words: list
     :param words: A list of strings to put into the stream.
     '''
     for w in words:
         try:
-            conn.put_record(stream_name, w, w)
+            kinesis.put_record(StreamName=stream_name, Data=w, PartitionKey=w)
             print("Put word: " + w + " into stream: " + stream_name)
         except Exception as e:
             sys.stderr.write("Encountered an exception while trying to put a word: "
@@ -69,16 +65,12 @@ def put_words_in_stream_periodically(conn, stream_name, words, period_seconds):
     '''
     Puts words into a stream, then waits for the period to elapse then puts the words in again. There is no strict
     guarantee about how frequently we put each word into the stream, just that we will wait between iterations.
-
     :type conn: boto.kinesis.layer1.KinesisConnection
     :param conn: A connection to Amazon Kinesis
-
     :type stream_name: str
     :param stream_name: The name of a stream.
-
     :type words: list
     :param words: A list of strings to put into the stream.
-
     :type period_seconds: int
     :param period_seconds: How long to wait, in seconds, between iterations over the list of words.
     '''
@@ -90,10 +82,8 @@ def put_words_in_stream_periodically(conn, stream_name, words, period_seconds):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('''
 Puts words into a stream.
-
 # Using the -w option multiple times
 sample_wordputter.py -s STREAM_NAME -w WORD1 -w WORD2 -w WORD3 -p 3
-
 # Passing input from STDIN
 echo "WORD1\\nWORD2\\nWORD3" | sample_wordputter.py -s STREAM_NAME -p 3
 ''')
@@ -115,18 +105,19 @@ echo "WORD1\\nWORD2\\nWORD3" | sample_wordputter.py -s STREAM_NAME -p 3
     one of the standard credentials providers.
     '''
     print("Connecting to stream: {s} in {r}".format(s=stream_name, r=args.region))
-    conn = kinesis.connect_to_region(region_name = args.region)
+    kinesis = boto3.client('kinesis', region_name=args.region)
+
     try:
-        status = get_stream_status(conn, stream_name)
+        status = get_stream_status(kinesis, stream_name)
         if 'DELETING' == status:
             print('The stream: {s} is being deleted, please rerun the script.'.format(s=stream_name))
             sys.exit(1)
         elif 'ACTIVE' != status:
-            wait_for_stream(conn, stream_name)
+            wait_for_stream(kinesis, stream_name)
     except:
         # We'll assume the stream didn't exist so we will try to create it with just one shard
-        conn.create_stream(stream_name, 1)
-        wait_for_stream(conn, stream_name)
+        kinesis.create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream(kinesis, stream_name)
     # Now the stream should exist
     if len(args.words) == 0:
         print('No -w options provided. Waiting on input from STDIN')
@@ -134,6 +125,6 @@ echo "WORD1\\nWORD2\\nWORD3" | sample_wordputter.py -s STREAM_NAME -p 3
     else:
         words = args.words
     if args.period != None:
-        put_words_in_stream_periodically(conn, stream_name, words, args.period)
+        put_words_in_stream_periodically(kinesis, stream_name, words, args.period)
     else:
-        put_words_in_stream(conn, stream_name, words)
+        put_words_in_stream(kinesis, stream_name, words)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.0.6'
+PACKAGE_VERSION = '2.1.0'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Prepare for KCL Python Release 2.1.0
- Upgrade Java dependencies to match KCL release v2.4.4
- Note that POM file is copied from KCL-NodeJS: https://github.com/awslabs/amazon-kinesis-client-nodejs/blob/master/pom.xml

*Testing*
- Local testing
```
# producer
python sample_kinesis_wordputter.py -r us-west-2 --stream kclpysample -w cat -w dog -w bird -w lobster -p 5
# consumer
`python amazon_kclpy_helper.py --print_command \
--java /Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home/bin/java \
--properties sample.properties`
```
- pytest
```
 11 passed, 2 warnings in 0.17s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
