### PR TITLE
Include the pom file in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include NOTICE.txt
 include README.md
+include pom.xml

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ all languages.
 
 ## Release Notes
 
+### Release 2.1.1 (January 17, 2023)
+* Include the pom file in MANIFEST
+
 ### Release 2.1.0 (January 12, 2023)
 * Upgraded to use version 2.4.4 of the [Amazon Kinesis Client library][kinesis-github]
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.1.0'
+PACKAGE_VERSION = '2.1.1'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-client-python/issues/205

*Description of changes:*
- `pom.xml` is missing from the dist file

*Testing*
- Tested locally that `pom.xml` is added to the dist correctly using `python setup.py sdist`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
