### PR TITLE
Add aws-java-sdk-sts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.5.1</version>


### PR DESCRIPTION
* Appears to be required for using an assumed role via an IRSA
* Currently, when using the `WebIdentityTokenCredentialsProvider`, the following
error is shown: `To use assume role profiles the aws-java-sdk-sts module must be on the class path.`
