### PR TITLE
Add aws-java-sdk-sts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.5.1</version>


### PR DESCRIPTION
* Required for using WebIdentityTokenCredentialsProvider which is necessary for using IRSA
* This was added in [this PR](https://github.com/awslabs/amazon-kinesis-client-python/pull/133) but removed [here](https://github.com/awslabs/amazon-kinesis-client-python/commit/bc09d8b853a1da57761387182814ee7d03ae708b)

[Related issue](https://github.com/awslabs/amazon-kinesis-client-python/issues/129)