### PR TITLE
Update dependabot.yml to use pip package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule: 
       interval: "weekly"


### PR DESCRIPTION
Updating the master branch with the correct package-ecosystem so that dependabot PRs can start being published for this repository


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
