### PR TITLE
Upgrade KCL Java dependency from 2.4.4 to 2.5.1 and Added streamArn support in KCL Python

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client-multilang</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -133,6 +133,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>

--- a/samples/sample.properties
+++ b/samples/sample.properties
@@ -5,7 +5,7 @@ executableName = sample_kclpy_app.py
 
 # The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
 # Important: streamArn takes precedence over streamName if both are set
-streamArn = arn:aws:kinesis:us-east-5:ACCOUNT_ID:stream/kclpysample
+streamArn = arn:aws:kinesis:us-east-5:000000000000:stream/kclpysample
 
 # The name of an Amazon Kinesis stream to process.
 # Important: streamArn takes precedence over streamName if both are set

--- a/samples/sample.properties
+++ b/samples/sample.properties
@@ -3,7 +3,12 @@
 # over STDIN and STDOUT according to the multi-language protocol.
 executableName = sample_kclpy_app.py
 
+# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
+# Important: streamArn takes precedence over streamName if both are set
+streamArn = arn:aws:kinesis:us-east-5:ACCOUNT_ID:stream/kclpysample
+
 # The name of an Amazon Kinesis stream to process.
+# Important: streamArn takes precedence over streamName if both are set
 streamName = kclpysample
 
 # Used by the KCL as the name of this application. Will be used as the name


### PR DESCRIPTION
*Description of changes:*
- Updated Python sample.properties to support streamArn. This is an extension of the [KCL Java - Multilang PR](https://github.com/awslabs/amazon-kinesis-client/pull/1143) to support parsing streamName from streamArn.
- Upgraded KCL dependencies 
## Testing
### Scenario #0 - Existing Functionality - streamName set and streamArn propert DNE
Config:
```
...
# over STDIN and STDOUT according to the multi-language protocol.
executableName = sample_kclpy_app.py

# The name of an Amazon Kinesis stream to process.
# Important: streamArn takes precedence over streamName if both are set
streamName = words
```
Output
```
2023-06-26 11:48:07,056 [main] INFO  s.a.k.m.MultiLangDaemonConfig [NONE] - Running PythonKCLSample to process stream words with executable sample_kclpy_app.py 
```
### Scenario #1 - streamName and streamArn passed in. KCL uses streamArn
Config:
```
# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
# Important: streamArn takes precedence over streamName if both are set
streamArn = arn:aws:kinesis:us-east-5:000000000000:stream/words

# The name of an Amazon Kinesis stream to process.
# Important: streamArn takes precedence over streamName if both are set
streamName = ignoreThisStream
```
Output
```
39:03,298 [main] INFO  s.a.k.m.MultiLangDaemonConfig [NONE] - Running PythonKCLSample to process stream words with executable sample_kclpy_app.py
```
### Scenario #2 - Only streamArn is passed in
Config
```
# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
# Important: streamArn takes precedence over streamName if both are set
streamArn = arn:aws:kinesis:us-east-5:000000000000:stream/words

# The name of an Amazon Kinesis stream to process.
# Important: streamArn takes precedence over streamName if both are set
streamName = 
```
Ouput
```
2023-06-26 11:43:15,536 [main] INFO  s.a.k.m.MultiLangDaemonConfig [NONE] - Running PythonKCLSample to process stream words with executable sample_kclpy_app.py 
```
### Scenario #3 - Only streamName is passed in
Config
```
# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
# Important: streamArn takes precedence over streamName if both are set
streamArn = 

# The name of an Amazon Kinesis stream to process.
# Important: streamArn takes precedence over streamName if both are set
streamName = words
```
Output
```
2023-06-26 11:44:17,034 [main] INFO  s.a.k.m.MultiLangDaemonConfig [NONE] - Running PythonKCLSample to process stream words with executable sample_kclpy_app.py 
```
### Scenario #4 - Neither are set
Config:
```
# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
# Important: streamArn takes precedence over streamName if both are set
streamArn = 

# The name of an Amazon Kinesis stream to process.
# Important: streamArn takes precedence over streamName if both are set
streamName = 
```
Output:
```
java.lang.IllegalArgumentException: Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.
        at org.apache.commons.lang3.Validate.notBlank(Validate.java:441)
        at software.amazon.kinesis.multilang.config.KinesisClientLibConfigurator.getConfiguration(KinesisClientLibConfigurator.java:84)
        at software.amazon.kinesis.multilang.MultiLangDaemonConfig.<init>(MultiLangDaemonConfig.java:108)
        at software.amazon.kinesis.multilang.MultiLangDaemonConfig.<init>(MultiLangDaemonConfig.java:81)
        at software.amazon.kinesis.multilang.MultiLangDaemonConfig.<init>(MultiLangDaemonConfig.java:65)
        at software.amazon.kinesis.multilang.MultiLangDaemon.buildMultiLangDaemonConfig(MultiLangDaemon.java:171)
        at software.amazon.kinesis.multilang.MultiLangDaemon.main(MultiLangDaemon.java:220)
Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.
Usage: amazon-kinesis-client MultiLangDaemon [options]
  Options:
    -l, --log-configuration
      File location of logback.xml to be override the default
    -p, --properties-file
      Properties file to be used with the KCL
```
==========

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
