### PR TITLE
Updated Python Versions for GH Actions - Update run-unit-tests.yml

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -16,8 +16,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r test_requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest
+        
+  build-python-legacy:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6]
+        os: [ubuntu-20.04, macOS-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -16,31 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
         os: [ubuntu-latest, macOS-latest, windows-latest ]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
-    - name: Test with pytest
-      run: |
-        pytest
-        
-  build-python-legacy:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6]
-        os: [ubuntu-20.04, macOS-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
1. Removed python 3.6 version from GH Actions as it is EoL and no longer supproted in ubunto latest. 
- See ongoing issue: https://github.com/actions/setup-python/issues/544
2. Added python verison 3.11 to be tested against

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
