### PR TITLE
Preparing KCL Python for new minor version 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ all languages.
 
 ## Release Notes
 
+### Release 2.1.2 (June 29, 2023)
+* Added the ability to pass in streamArn to multilang Daemon [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/221)
+* Upgraded KCL and KCL-Multilang Dependencies from 2.4.4 to 2.5.1 [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/221)
+* Upgraded Google Guava dependency from 31.0.1-jre to 32.0.0-jre [PR #223](https://github.com/awslabs/amazon-kinesis-client-python/pull/223)
+* Added aws-java-sdk-sts dependency [PR #212](https://github.com/awslabs/amazon-kinesis-client-python/pull/212)
+
 ### Release 2.1.1 (January 17, 2023)
 * Include the pom file in MANIFEST
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.1.1'
+PACKAGE_VERSION = '2.1.2'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
Updated version and README.md to prepare for version 2.1.2 (from 2.1.1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
