### PR TITLE
Revbump KCL to `2.5.2` to enable NestedPropertyKey support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <properties>
         <awssdk.version>2.19.2</awssdk.version>
         <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
+        <kcl.version>2.5.2</kcl.version>
         <netty.version>4.1.86.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
@@ -13,12 +14,12 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client-multilang</artifactId>
-            <version>2.5.1</version>
+            <version>${kcl.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>2.5.1</version>
+            <version>${kcl.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/samples/sample.properties
+++ b/samples/sample.properties
@@ -20,6 +20,9 @@ applicationName = PythonKCLSample
 # The DefaultAWSCredentialsProviderChain checks several other providers, which is
 # described here:
 # http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
+#
+# For additional configuration, including nested properties, see:
+# https://github.com/awslabs/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md
 AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
 
 # Appended to the user agent of the KCL. Does not impact the functionality of the


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Revbump KCL to `2.5.2` to enable NestedPropertyKey support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
