### PR TITLE
Preparing KCL Python for new minor version 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ all languages.
 
 ## Release Notes
 
+### Release 2.1.3 (August 8, 2023)
+* Added the ability to specify sts endpoint and region [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/230)
+* Upgraded KCL and KCL-Multilang Dependencies from 2.5.1 to 2.5.2 [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/230)
+
 ### Release 2.1.2 (June 29, 2023)
 * Added the ability to pass in streamArn to multilang Daemon [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/221)
 * Upgraded KCL and KCL-Multilang Dependencies from 2.4.4 to 2.5.1 [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/221)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ all languages.
 ## Release Notes
 
 ### Release 2.1.3 (August 8, 2023)
-* Added the ability to specify sts endpoint and region [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/230)
+* Added the ability to specify STS endpoint and region [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/230)
 * Upgraded KCL and KCL-Multilang Dependencies from 2.5.1 to 2.5.2 [PR #221](https://github.com/awslabs/amazon-kinesis-client-python/pull/230)
 
 ### Release 2.1.2 (June 29, 2023)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.1.2'
+PACKAGE_VERSION = '2.1.3'
 PYTHON_REQUIREMENTS = [
     'boto',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION

Updated version and README.md to prepare for version 2.1.3 (from 2.1.2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
