### PR TITLE
Update boto dependency to boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto
+boto3
 argparse

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
 PACKAGE_VERSION = '2.1.4'
 PYTHON_REQUIREMENTS = [
-    'boto',
+    'boto3',
     # argparse is part of python2.7 but must be declared for python2.6
     'argparse',
 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates the `boto` dependency to be `boto3`
`boto3` is used in the sample https://github.com/awslabs/amazon-kinesis-client-python/blob/master/samples/sample_kinesis_wordputter.py#L12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
