### PR TITLE
Only install argparse for python versions <= 3.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 boto3
-argparse
+argparse ; python_version <= "3.1"


### PR DESCRIPTION
*Issue #, if available:*
[Issue 250](https://github.com/awslabs/amazon-kinesis-client-python/issues/250)

*Description of changes:*
Modifies requirements.txt to make argparse only required for python versions <= 3.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
