### PR TITLE
Update dependencies for deprecated sdk1 and bumped kcl dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ all languages.
         * `LeaseAssignmentManager`
         * `WorkerMetricStatsReporter`
         * `LeaseDiscovery`
+---
+For **2.x** and **1.x** release notes, please see [v2.x/README.md](https://github.com/awslabs/amazon-kinesis-client-python/blob/v2.x/README.md#release-notes)
+
+[amazon-kinesis-shard]: http://docs.aws.amazon.com/kinesis/latest/dev/key-concepts.html
+[amazon-kinesis-docs]: http://aws.amazon.com/documentation/kinesis/
+[amazon-kcl]: http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-record-processor-app.html
+[multi-lang-daemon]: https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/multilang/package-info.java
+[kinesis]: http://aws.amazon.com/kinesis
+[amazon-kinesis-ruby-github]: https://github.com/awslabs/amazon-kinesis-client-ruby
+[kinesis-github]: https://github.com/awslabs/amazon-kinesis-client
+[boto]: http://boto.readthedocs.org/en/latest/
+[DefaultCredentialsProvider]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
+[kinesis-forum]: http://developer.amazonwebservices.com/connect/forum.jspa?forumID=169
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <netty.version>4.1.108.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.3.12</logback.version>
+        <logback.version>1.3.14</logback.version>
     </properties>
     <dependencies>
         <dependency>
@@ -280,22 +280,22 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.7</version>
+            <version>4.27.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.13</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>3.1.5</version>
+            <version>3.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -338,16 +338,6 @@
             <version>4.4.15</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>${aws-java-sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${aws-java-sdk.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.11.4</version>
@@ -355,7 +345,13 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.13</version>
+            <version>1.1.19</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk-sts</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -380,7 +376,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -390,7 +386,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.2</version>
+            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Issue:
v3.0.0 release of Python Multilang had hanging dependencies on `com.amazonaws` that were intended to be removed. 

When running `setup.py download_jars`, users may see a message like...
> RuntimeError: The following jars were not installed because they were not
present in this package at the time of installation:
  amazon_kclpy/jars/aws-java-sdk-core-${aws-java-sdk.version}.jar
  amazon_kclpy/jars/aws-java-sdk-sts-${aws-java-sdk.version}.jar
This doesn't affect the rest of the installation, but may make it more
difficult for you to run the sample app and get started.

**This can be safely ignored and subsequent steps of running the KCL will work as expected**. However, this is a deceptive error that will mislead users.

Removes those hanging dependencies so the error does not appear, bumps other dependencies to Java KCL versions, and fixes README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
