### PR TITLE
Upgrade to v3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ all languages.
 
 ## Release Notes
 
+### Release 3.0.1 (November 6, 2024)
+* Fixes installation issue.
+
 ### Release 3.0.0 (November 6, 2024)
+
+**This release has been pulled from PyPI. The use of this release can cause downloads to fail. Downgrade to 2.x or upgrade to the next release 3.0.1.**
 * New lease assignment / load balancing algorithm
     * KCL 3.x introduces a new lease assignment and load balancing algorithm. It assigns leases among workers based on worker utilization metrics and throughput on each lease, replacing the previous lease count-based lease assignment algorithm.
     * When KCL detects higher variance in CPU utilization among workers, it proactively reassigns leases from over-utilized workers to under-utilized workers for even load balancing. This ensures even CPU utilization across workers and removes the need to over-provision the stream processing compute hosts.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '3.0.0'
+PACKAGE_VERSION = '3.0.1'
 PYTHON_REQUIREMENTS = [
     'boto3',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
### Release 3.0.1 (November 6, 2024)
* Fixes .pom issue with deprecated dependencies that caused failures during install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
