### PR TITLE
Upgrade to KCL 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ all languages.
 
 ## Release Notes
 
+### Release 2.1.6 (January 22, 2025)
+* Updates KCL version to use KCL 2.6.1. Brings in [changes from the KCL 2.6.1 release][2.6.1 changelog]. 
+
 ### Release 2.1.5 (May 29, 2024)
 * Fixed CI due to different macOS architecture [PR #246](https://github.com/awslabs/amazon-kinesis-client-python/pull/246)
 * Added necessary Java SDKs to run sample [PR #248](https://github.com/awslabs/amazon-kinesis-client-python/pull/248)
@@ -342,6 +345,7 @@ all languages.
 [boto]: http://boto.readthedocs.org/en/latest/
 [DefaultCredentialsProvider]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
 [kinesis-forum]: http://developer.amazonwebservices.com/connect/forum.jspa?forumID=169
+[2.6.1 changelog]: https://github.com/awslabs/amazon-kinesis-client/blob/v2.6.1/CHANGELOG.md#release-261-2024-12-13
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <awssdk.version>2.25.11</awssdk.version>
+        <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
         <kcl.version>2.6.1</kcl.version>
         <netty.version>4.1.108.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.3.12</logback.version>
+        <logback.version>1.3.14</logback.version>
     </properties>
     <dependencies>
         <dependency>
@@ -269,22 +269,22 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.7</version>
+            <version>4.27.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.13</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>3.1.5</version>
+            <version>3.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -344,7 +344,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.13</version>
+            <version>1.1.19</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -369,7 +369,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -379,7 +379,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.2</version>
+            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.25.11</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
-        <kcl.version>2.5.8</kcl.version>
+        <kcl.version>2.6.1</kcl.version>
         <netty.version>4.1.108.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.1.5'
+PACKAGE_VERSION = '2.1.6'
 PYTHON_REQUIREMENTS = [
     'boto3',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
Bumps KCL version to 2.6.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
