### PR TITLE
Remove python 3.7 from CI and use macOS-latest

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -16,11 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
-        # TODO: revert macOS-13 back to macOS-latest
-        # macOS-latest switched architectures and does not have older versions of python available
-        # https://github.com/actions/setup-python/issues/856
-        os: [ubuntu-latest, macOS-13, windows-latest ]
+        python-version: [3.8, 3.9, "3.10", 3.11]
+        os: [ubuntu-latest, macOS-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- 3.7 ubuntu is not used and python 3.7 is EOL
- Go back to macOS-latest platform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
