### PR TITLE
Release v2.2.0

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -16,11 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
-        # TODO: revert macOS-13 back to macOS-latest
-        # macOS-latest switched architectures and does not have older versions of python available
-        # https://github.com/actions/setup-python/issues/856
-        os: [ubuntu-latest, macOS-13, windows-latest ]
+        python-version: [3.8, 3.9, "3.10", 3.11]
+        os: [ubuntu-latest, macOS-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ access.
 For questions regarding Amazon Kinesis Service and the client libraries please visit the
 [Amazon Kinesis Forums][kinesis-forum]
 
-## 🚨Important: Migration to KCL 2.7 or later with MultiLangDaemon - Credential Provider Changes Required
-KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. All MultiLangDaemon users
-upgrading from earlier versions must update their credential provider configuration in the `.properties` file to use
-credentials provider name for AWS SDK for Java 2.x. Failure to do this will cause your multilang KCL application to fail
-during startup with credential provider construction errors. Please check the following link for the credentials
-provider mapping and MultiLangDaemon credentials provider configuration guide.
+## 🚨Important: Migration to Python KCL 2.2.0 or later with MultiLangDaemon - Credential Provider Changes Required
+Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the KCL python 2.x versions,
+v2.2.0 is the first node release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
+their credential provider configuration in the `.properties` file to use credentials provider name for AWS SDK for Java 2.x.
+Failure to do this will cause your multilang KCL application to fail during startup with credential provider construction errors.
+Please check the following link for the credentials provider mapping and MultiLangDaemon credentials provider configuration guide
 
 - [AWS SDK for Java 1.x to 2.x Credentials Provider Mapping](aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html#credentials-changes-mapping)
 - [KCL Multilang Credentials Provider Configuration Guide](https://github.com/aws/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md)
@@ -156,7 +156,7 @@ all languages.
 * The [Amazon Kinesis Forum][kinesis-forum]
 
 ## Release Notes
-### Release 2.2.0 (2025-03-12)
+### Release 2.2.0 (2025-03-12) - IMPORTANT: See section ``Migration to Python  KCL 2.2.0`` to ensure upgrading does not break compatibility
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ all languages.
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
+* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade logback.version from 1.3.14 to 1.5.16
+* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
 
 ### Release 2.1.6 (January 22, 2025)
 * Updates KCL version to use KCL 2.6.1. Brings in [changes from the KCL 2.6.1 release][2.6.1 changelog]. 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ access.
 For questions regarding Amazon Kinesis Service and the client libraries please visit the
 [Amazon Kinesis Forums][kinesis-forum]
 
+## 🚨Important: Migration to KCL 2.7 or later with MultiLangDaemon - Credential Provider Changes Required
+KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. All MultiLangDaemon users
+upgrading from earlier versions must update their credential provider configuration in the `.properties` file to use
+credentials provider name for AWS SDK for Java 2.x. Failure to do this will cause your multilang KCL application to fail
+during startup with credential provider construction errors. Please check the following link for the credentials
+provider mapping and MultiLangDaemon credentials provider configuration guide.
+
+- [AWS SDK for Java 1.x to 2.x Credentials Provider Mapping](aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html#credentials-changes-mapping)
+- [KCL Multilang Credentials Provider Configuration Guide](https://github.com/aws/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md)
+
+
 ## Running the Sample
 
 Using the `amazon_kclpy` package requires the MultiLangDaemon which is provided
@@ -145,6 +156,10 @@ all languages.
 * The [Amazon Kinesis Forum][kinesis-forum]
 
 ## Release Notes
+### Release 2.7.0 (2025-03-12)
+* [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
+    * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
+    * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
 
 ### Release 2.1.6 (January 22, 2025)
 * Updates KCL version to use KCL 2.6.1. Brings in [changes from the KCL 2.6.1 release][2.6.1 changelog]. 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For questions regarding Amazon Kinesis Service and the client libraries please v
 [Amazon Kinesis Forums][kinesis-forum]
 
 ## 🚨Important: Migration to Python KCL 2.2.0 or later with MultiLangDaemon - Credential Provider Changes Required
-Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the KCL python 2.x versions,
+Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the KCL Python 2.x versions,
 v2.2.0 is the first Python release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
 their credential provider configuration in the `.properties` file to use credentials provider name for AWS SDK for Java 2.x.
 Failure to do this will cause your multilang KCL application to fail during startup with credential provider construction errors.
@@ -156,7 +156,7 @@ all languages.
 * The [Amazon Kinesis Forum][kinesis-forum]
 
 ## Release Notes
-### Release 2.2.0 (2025-03-12) - IMPORTANT: See section ``Migration to Python  KCL 2.2.0`` to ensure upgrading does not break compatibility
+### Release 2.2.0 (2025-03-12) - IMPORTANT: See section ``Migration to Python KCL 2.2.0`` to ensure upgrading does not break compatibility
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For questions regarding Amazon Kinesis Service and the client libraries please v
 
 ## 🚨Important: Migration to Python KCL 2.2.0 or later with MultiLangDaemon - Credential Provider Changes Required
 Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the KCL python 2.x versions,
-v2.2.0 is the first node release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
+v2.2.0 is the first Python release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
 their credential provider configuration in the `.properties` file to use credentials provider name for AWS SDK for Java 2.x.
 Failure to do this will cause your multilang KCL application to fail during startup with credential provider construction errors.
 Please check the following link for the credentials provider mapping and MultiLangDaemon credentials provider configuration guide

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ all languages.
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
-* [#89](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade logback.version from 1.3.14 to 1.5.16
-* [#89](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
+* [#270](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade logback.version from 1.3.14 to 1.5.16
+* [#270](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
 
 ### Release 2.1.6 (January 22, 2025)
 * Updates KCL version to use KCL 2.6.1. Brings in [changes from the KCL 2.6.1 release][2.6.1 changelog]. 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ all languages.
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
-* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade logback.version from 1.3.14 to 1.5.16
-* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
+* [#89](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade logback.version from 1.3.14 to 1.5.16
+* [#89](https://github.com/awslabs/amazon-kinesis-client-python/pull/270) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
 
 ### Release 2.1.6 (January 22, 2025)
 * Updates KCL version to use KCL 2.6.1. Brings in [changes from the KCL 2.6.1 release][2.6.1 changelog]. 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ all languages.
 * The [Amazon Kinesis Forum][kinesis-forum]
 
 ## Release Notes
-### Release 2.7.0 (2025-03-12)
+### Release 2.2.0 (2025-03-12)
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
     * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
     * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <netty.version>4.1.108.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.3.14</logback.version>
+        <logback.version>1.5.16</logback.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
-        <kcl.version>2.6.1</kcl.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <kcl.version>2.7.0</kcl.version>
+        <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
         <logback.version>1.5.16</logback.version>

--- a/samples/sample.properties
+++ b/samples/sample.properties
@@ -17,13 +17,12 @@ streamName = kclpysample
 applicationName = PythonKCLSample
 
 # Users can change the credentials provider the KCL will use to retrieve credentials.
-# The DefaultAWSCredentialsProviderChain checks several other providers, which is
+# Expected key name (case-sensitive):
+# AwsCredentialsProvider / AwsCredentialsProviderDynamoDB / AwsCredentialsProviderCloudWatch
+# The DefaultCredentialsProvider checks several other providers, which is
 # described here:
-# http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
-#
-# For additional configuration, including nested properties, see:
-# https://github.com/awslabs/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md
-AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
+# https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
+AwsCredentialsProvider = DefaultCredentialsProvider
 
 # Appended to the user agent of the KCL. Does not impact the functionality of the
 # KCL in any other way.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.1.6'
+PACKAGE_VERSION = '2.2.0'
 PYTHON_REQUIREMENTS = [
     'boto3',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
*Description of changes:* Prepare for release 2.2.0. Updating release notes, sample.properties and version number.

### Release 2.2.0 (2025-03-12)
* [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
    * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
    * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade logback.version from 1.3.14 to 1.5.16
* [#89](https://github.com/awslabs/amazon-kinesis-client-ruby/pull/89) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
