### PR TITLE
Add ability to set mvn repo search URL with a Unique ENV Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ From the root of this repo, run:
     python setup.py download_jars
     python setup.py install
 
+If you'd like to override the default search location for the jars, you can set the `KCL_MVN_REPO_SEARCH_URL`
+environment variable to the location of the maven repository you'd like to use.
+
+    export KCL_MVN_REPO_SEARCH_URL=https://path/to/maven/repo
+
 Now the `amazon_kclpy` and [boto][boto] (used by the sample putter script) and required
 jars should be installed in your environment. To start the sample putter, run:
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ Which will download the required jars and rerun the install.
         # Sample url:
         # https://search.maven.org/remotecontent?filepath=org/apache/httpcomponents/httpclient/4.2/httpclient-4.2.jar
         #
-        prefix = 'https://search.maven.org/remotecontent?filepath='
+        prefix = os.getenv("KCL_MVN_REPO_SEARCH_URL", 'https://search.maven.org/remotecontent?filepath=')
         return '{prefix}{path}/{artifact_id}/{version}/{dest}'.format(
                                         prefix=prefix,
                                         path='/'.join(group_id.split('.')),


### PR DESCRIPTION
*Issue #, if available:*
#209 

*Description of changes:*
This PR add the ability to set a unique URL to download the required Jars from. Unlike #216, this adds the ability to set the entire URL while making sure the env name is unique.

This PR is specifically useful for teams that need to use a private Artifactory or hub to download the jars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.