### PR TITLE
Revert "Bump netty.version from 4.1.118.Final to 4.2.1.Final (#285)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <kcl.version>3.0.3</kcl.version>
-        <netty.version>4.2.1.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
         <logback.version>1.3.15</logback.version>


### PR DESCRIPTION
This reverts commit 2d08638dca28a8afcd77ee78b209dc8e16aa8d85.

*Issue #, if available:*

*Description of changes:* Revertting dependabot upgrade netty.version from 4.1.118.Final to 4.2.1.Final


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
