### PR TITLE
fix: upgrade commons-lang3 to remediate CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
*Description of changes:*

`commons-lang3` versions before 3.18.0 are affected by CVE-2025-48924.

This PR bumps from 3.14.0 to 3.18.0 to remediate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
