### PR TITLE
Netty and jackson version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
         <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
         <kcl.version>2.7.0</kcl.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.125.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
         <!--do not upgrade to logback version 1.5.x, as this is not compatible with JDK 8-->
         <logback.version>1.3.15</logback.version>
     </properties>


### PR DESCRIPTION
Upgrade io.netty:netty-codec from 4.1.118.Final to 4.1.125.Final
Upgrade com.fasterxml.jackson.core:jackson-core from 2.13.5 to 2.15.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
