### PR TITLE
Release v2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ all languages.
 
 ## Release Notes
 ### Release 2.2.2 (September 10, 2025)
-* [#318](https://github.com/awslabs/amazon-kinesis-client-python/pull/318) Upgrade io.netty:netty-codec from 4.1.118.Final to 4.1.125.Final
-* [#304](https://github.com/awslabs/amazon-kinesis-client-python/pull/304) Upgrade com.fasterxml.jackson.core:jackson-core from 2.13.5 to 2.15.0
+* [#321](https://github.com/awslabs/amazon-kinesis-client-python/pull/321) Upgrade io.netty:netty-codec from 4.1.118.Final to 4.1.125.Final
+* [#321](https://github.com/awslabs/amazon-kinesis-client-python/pull/321) Upgrade com.fasterxml.jackson.core:jackson-core from 2.13.5 to 2.15.0
 
 ### Release 2.2.1 (March 22, 2025)
 * Downgrade logback from 1.5.16 to 1.3.15 to maintain JDK 8 compatability

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ all languages.
 * The [Amazon Kinesis Forum][kinesis-forum]
 
 ## Release Notes
+### Release 2.2.2 (September 10, 2025)
+* [#318](https://github.com/awslabs/amazon-kinesis-client-python/pull/318) Upgrade io.netty:netty-codec from 4.1.118.Final to 4.1.125.Final
+* [#304](https://github.com/awslabs/amazon-kinesis-client-python/pull/304) Upgrade com.fasterxml.jackson.core:jackson-core from 2.13.5 to 2.15.0
+
 ### Release 2.2.1 (March 22, 2025)
 * Downgrade logback from 1.5.16 to 1.3.15 to maintain JDK 8 compatability
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 PACKAGE_NAME = 'amazon_kclpy'
 JAR_DIRECTORY = os.path.join(PACKAGE_NAME, 'jars')
-PACKAGE_VERSION = '2.2.1'
+PACKAGE_VERSION = '2.2.2'
 PYTHON_REQUIREMENTS = [
     'boto3',
     # argparse is part of python2.7 but must be declared for python2.6


### PR DESCRIPTION
# Release Notes

## Release 2.2.2 (September 10, 2025)
* https://github.com/awslabs/amazon-kinesis-client-python/pull/318 Upgrade io.netty:netty-codec from 4.1.118.Final to 4.1.125.Final
* https://github.com/awslabs/amazon-kinesis-client-python/pull/304 Upgrade com.fasterxml.jackson.core:jackson-core from 2.13.5 to 2.15.0

Applied above commits to v2.x branch in https://github.com/awslabs/amazon-kinesis-client-python/pull/319

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.