### PR TITLE
bump fasterxml-jackson from 2.15.0 to 2.21.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <kcl.version>3.1.3</kcl.version>
         <netty.version>4.2.13.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.21.1</fasterxml-jackson.version>
         <logback.version>1.3.16</logback.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump fasterxml dependency from 2.15.0 to 2.21.1. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
